### PR TITLE
Fix Snowflake-breaking SQL dialect issues in lab_cohorts.sql and 00_setup.sql

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,27 @@ is up to you — `connectionDetails` is defined by you in `run.R` (see step 2 in
 > good guidance for resolving the Python dependency:
 > <https://github.com/OHDSI/Artemis#installation>.
 
+> [!WARNING]
+> **Pin `pandas` to the 2.x line (e.g. `2.2.3`) in ARTEMIS's Python environment —
+> `pandas 3.x` silently breaks regimen alignment.** Confirmed 2026-07-31: with
+> `pandas==3.0.3` installed in the reticulate venv ARTEMIS builds (usually
+> `<Rlib>/ARTEMIS/.r-reticulate`), `ARTEMIS::generateRawAlignments()` /
+> `runArtemis()` fails with `Error in if (nrow(output) == 0) { : argument is of
+> length zero` — **after** "Generating raw alignments" reports 100% complete, so
+> it looks like an alignment/data problem, not an environment one. It is not:
+> the Cython alignment engine's return value silently fails to convert to a
+> proper R data.frame under pandas 3.x, for **any** input data (verified with
+> correctly-tokenized, correctly-matched regimen strings — reproduces even in a
+> direct, standalone call to `ARTEMIS::generateRawAlignments()`). Fix:
+> ```bash
+> <path-to-ARTEMIS-venv>/bin/python3 -m pip install "pandas==2.2.3"
+> ```
+> After downgrading, the exact same call returns a proper populated data.frame
+> (132,920 correct alignments in testing, vs. a hard crash before). Check the
+> installed version with `<venv>/bin/python3 -m pip list | grep -i pandas`. If
+> a future ARTEMIS release is confirmed pandas-3-compatible, this note (and the
+> pin) can be dropped.
+
 ### Installing the dependencies
 
 Two ways — renv first (reproducible), or a plain install if you prefer.

--- a/sql/lab_cohorts.sql
+++ b/sql/lab_cohorts.sql
@@ -810,7 +810,9 @@ INSERT INTO @work_database_schema.@cat_concept_table (cat, measurement_concept_i
 -- table for unit conversion, including non-UCUM units
 DROP TABLE IF EXISTS @work_database_schema.@unit_factor_table;
 -- standard_value = value_as_number * factor + offset   (offset<>0 only for HbA1c mmol/mol, which is affine)
-CREATE TABLE @work_database_schema.@unit_factor_table (cat varchar(40), unit_concept_id int, factor float, offset float, is_std bit);
+-- is_std: 'bit' isn't a portable ANSI type (unsupported on Snowflake); using int since every
+-- reference to this column compares against literal 1 (see is_std=1 in the comment below).
+CREATE TABLE @work_database_schema.@unit_factor_table (cat varchar(40), unit_concept_id int, factor float, offset float, is_std int);
 INSERT INTO @work_database_schema.@unit_factor_table (cat, unit_concept_id, factor, offset, is_std) VALUES
  ('ALT',8645,1.0,0.0,1),
  ('ALT',8923,1.0,0.0,0),
@@ -1065,14 +1067,21 @@ SELECT
       WHEN 'both'  THEN CASE WHEN g.p25 > 0 AND g.p75 > 0 AND n.range_low > 0 AND n.range_high > 0
           THEN ABS( (LOG10(n.range_low)+LOG10(n.range_high))/2
                   - (LOG10(g.p25*s.factor+s.offset)+LOG10(g.p75*s.factor+s.offset))/2 ) END
+      -- GREATEST-via-VALUES (the SQL Server <2022 compatibility trick this file's header
+      -- flags) fails on Snowflake specifically: a VALUES()-clause derived table there can't
+      -- reference outer-query columns ("Invalid expression [CORRELATION(...)] in VALUES
+      -- clause" -- confirmed via a minimal repro against live Snowflake). Native GREATEST()
+      -- works on Snowflake, Postgres, Redshift, Oracle, and SQL Server 2022+ (verified
+      -- SqlRender has no dialect-specific translation rule for GREATEST -- passes through
+      -- unchanged everywhere); only pre-2022 SQL Server loses compatibility here.
       WHEN 'upper' THEN CASE WHEN g.p03 > 0 AND g.p97 > 0 AND n.range_high > 0
-          THEN (SELECT MAX(v) FROM (VALUES (0.0),
+          THEN GREATEST(0.0,
                    (LOG10(n.range_high) - LOG10(g.p97*s.factor+s.offset)),
-                   (LOG10(g.p03*s.factor+s.offset) - LOG10(n.range_high)) ) t(v)) END
+                   (LOG10(g.p03*s.factor+s.offset) - LOG10(n.range_high)) ) END
       WHEN 'lower' THEN CASE WHEN g.p03 > 0 AND g.p97 > 0 AND n.range_low > 0
-          THEN (SELECT MAX(v) FROM (VALUES (0.0),
+          THEN GREATEST(0.0,
                    (LOG10(n.range_low) - LOG10(g.p97*s.factor+s.offset)),
-                   (LOG10(g.p03*s.factor+s.offset) - LOG10(n.range_low)) ) t(v)) END
+                   (LOG10(g.p03*s.factor+s.offset) - LOG10(n.range_low)) ) END
     END
   END AS dist_decade
 INTO @work_database_schema.@scored_table

--- a/sql/prestudy/chunks/00_setup.sql
+++ b/sql/prestudy/chunks/00_setup.sql
@@ -856,7 +856,7 @@ FROM (
         days_diff,
         ROW_NUMBER() OVER (
             PARTITION BY anchor_event, event_family, concept_id, person_id
-            ORDER BY DATEDIFF(DAY, '1900-01-01', event_date) ASC, event_date ASC
+            ORDER BY event_date ASC
         ) AS rn
     FROM #event_code_all_events
 ) x
@@ -1014,7 +1014,7 @@ FROM (
         days_diff,
         ROW_NUMBER() OVER (
             PARTITION BY anchor_event, event_family, time_relative, concept_id, person_id
-            ORDER BY DATEDIFF(DAY, '1900-01-01', event_date) ASC, event_date ASC
+            ORDER BY event_date ASC
         ) AS rn
     FROM #event_code_ba_events
 ) x

--- a/sql/prestudy/chunks/00_setup.sql
+++ b/sql/prestudy/chunks/00_setup.sql
@@ -856,7 +856,7 @@ FROM (
         days_diff,
         ROW_NUMBER() OVER (
             PARTITION BY anchor_event, event_family, concept_id, person_id
-            ORDER BY DATEDIFF(DAY, CAST('1900-01-01' AS DATE), event_date) ASC, event_date ASC
+            ORDER BY DATEDIFF(DAY, '1900-01-01', event_date) ASC, event_date ASC
         ) AS rn
     FROM #event_code_all_events
 ) x
@@ -1014,7 +1014,7 @@ FROM (
         days_diff,
         ROW_NUMBER() OVER (
             PARTITION BY anchor_event, event_family, time_relative, concept_id, person_id
-            ORDER BY DATEDIFF(DAY, CAST('1900-01-01' AS DATE), event_date) ASC, event_date ASC
+            ORDER BY DATEDIFF(DAY, '1900-01-01', event_date) ASC, event_date ASC
         ) AS rn
     FROM #event_code_ba_events
 ) x


### PR DESCRIPTION
## Summary
- `lab_cohorts.sql`: `unit_factor_table.is_std` changed `bit` -> `int` (Snowflake has no `BIT` type)
- `lab_cohorts.sql`: replace the SQL-Server-<2022-compatibility `VALUES`-based `MAX` trick with native `GREATEST()` — the `VALUES` form fails on Snowflake because a `VALUES` derived table can't reference outer-query columns there. Native `GREATEST`/`LEAST` is also the pattern OHDSI itself uses in canonical multi-dialect templates (e.g. `CohortPrevalence:inst/sql/pd4_era.sql`, `ClinicalCharacteristics`) — the `VALUES` trick has no precedent anywhere in the OHDSI org.
- `00_setup.sql`: the `ROW_NUMBER` tiebreak `ORDER BY DATEDIFF(DAY, CAST('1900-01-01' AS DATE), event_date) ASC, event_date ASC` is simplified to `ORDER BY event_date ASC`. The epoch-anchored `DATEDIFF` is a strictly monotonic function of `event_date` (a plain `DATE` column in both source temp tables), so it can never change the sort order, and the second `event_date ASC` key only breaks ties the first key couldn't already have left. This sidesteps the original Snowflake bug (SqlRender mistranslated the `CAST` into `TO_DATE(..., 'YYYYMMDD')`, a format that doesn't match the dashed literal) entirely, rather than trading it for a different literal-syntax question.
- README: documents an unrelated ARTEMIS/pandas-3.x incompatibility discovered during the same debugging session (pin to `pandas==2.2.3`)

## Verification
- Confirmed each dialect-sensitive translation via `SqlRender::translate()` across `sql server`, `postgresql`, `redshift`, `oracle`, `snowflake`, `spark`, and `pdw`
- Grepped `sql/` for the same patterns (`bit` columns, the `VALUES`/`GREATEST` trick, `CAST('<literal>' AS DATE)`, `DATE '<literal>'`, the epoch-anchored `DATEDIFF` idiom) — no other occurrences exist
- Checked OHDSI's canonical SqlRender-templated repos for precedent on both the `GREATEST` fix (confirmed: real HADES packages use it directly) and the `DATEDIFF`-literal question (no OHDSI package anchors `DATEDIFF` against a fixed literal at all — motivated dropping the anchor rather than picking a "safest" literal syntax)

## Test plan
- [ ] Re-run the pre-study diagnostics pipeline against a live Snowflake connection to confirm `lab_cohorts.sql` and `00_setup.sql` execute cleanly end-to-end
- [ ] Spot-check against a SQL Server test connection if available, to confirm no regression there