### PR TITLE
Fix Redshift correlated-subquery error in eligibility_2a-2d.sql

### DIFF
--- a/R/06_artemis_assessment.R
+++ b/R/06_artemis_assessment.R
@@ -35,9 +35,21 @@
 
 message("\n== ARTEMIS assessment ==")
 
+# artemisResult is normally still in scope from step (a) in the same session,
+# but step (a) persists it to disk too (see R/01_artemis.R), so a session that
+# only re-runs (b)-(e) can reload it here instead of re-running the alignment.
 if (!exists("artemisResult")) {
-  message("  artemisResult not in scope (ARTEMIS step (a) did not run this ",
-          "session) — skipping assessment.")
+  rdsPath <- file.path(settings$outputFolder, "artemis_result.rds")
+  if (file.exists(rdsPath)) {
+    message("  artemisResult not in scope (ARTEMIS step (a) did not run this ",
+            "session) — reloading from ", rdsPath)
+    artemisResult <- readRDS(rdsPath)
+  }
+}
+
+if (!exists("artemisResult")) {
+  message("  artemisResult not in scope and no saved artemis_result.rds found ",
+          "in the output folder — skipping assessment.")
 } else {
 
   minCell   <- settings$minCellCount

--- a/sql/eligibility_2a.sql
+++ b/sql/eligibility_2a.sql
@@ -42,13 +42,24 @@
 -- apply the eligibility logic as plain boolean algebra over those flags. Same
 -- semantics as the EXISTS version (a flag is 1 iff a qualifying record exists
 -- for that subject in the relevant window), same eligibility_2b/2c/2d pattern.
+--
+-- NOTE on statement shape — `WITH ... INSERT INTO ...` vs `INSERT INTO ...
+-- WITH ...` is NOT portable: Snowflake requires the WITH nested after the
+-- INSERT's column list (confirmed live), while SQL Server (T-SQL) requires
+-- WITH to precede INSERT entirely — SqlRender does not rewrite clause order
+-- across dialects, so neither placement alone works everywhere. We sidestep
+-- this by materialising the CTE result into a #temp table via the
+-- SqlRender-portable `SELECT ... INTO #temp FROM ...` idiom (translates to
+-- native SELECT INTO on SQL Server, CREATE TEMP TABLE AS on
+-- Postgres/Redshift/Snowflake — same idiom already used across OHDSI SQL),
+-- then a plain, CTE-free INSERT INTO ... SELECT FROM #temp.
 -- =============================================================================
 
 DELETE FROM @target_database_schema.@target_cohort_table
  WHERE cohort_definition_id = @target_cohort_id;
 
-INSERT INTO @target_database_schema.@target_cohort_table
-  (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
+DROP TABLE IF EXISTS #elig2a_tmp;
+
 WITH base AS (
   SELECT tc.subject_id, tc.cohort_start_date, tc.cohort_end_date,
          DATEADD(day, -@lab_window_before_days, tc.cohort_start_date) AS win_lo,
@@ -105,8 +116,8 @@ flags AS (
   FROM labs
   GROUP BY subject_id, cohort_start_date, cohort_end_date
 )
-SELECT @target_cohort_id AS cohort_definition_id,
-       subject_id, cohort_start_date, cohort_end_date
+SELECT subject_id, cohort_start_date, cohort_end_date
+  INTO #elig2a_tmp
   FROM flags
  WHERE
 
@@ -167,3 +178,12 @@ SELECT @target_cohort_id AS cohort_definition_id,
    -- Enfortumab: no pre-existing significant skin disorders (test 34).
    AND f_skin = 0
 ;
+
+INSERT INTO @target_database_schema.@target_cohort_table
+  (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
+SELECT @target_cohort_id AS cohort_definition_id,
+       subject_id, cohort_start_date, cohort_end_date
+  FROM #elig2a_tmp
+;
+
+DROP TABLE IF EXISTS #elig2a_tmp;

--- a/sql/eligibility_2a.sql
+++ b/sql/eligibility_2a.sql
@@ -30,6 +30,18 @@
 --   24 ECOG 0   25 ECOG 1   26 ECOG 2   28 Liver metastasis
 --   30 Hb >= 5.6 mmol/L   32 Neuropathy grade < 2   34 No skin disorder
 --   35 No polyuria   36 No polydipsia (for HbA1c 7-8% path with test 16)
+--
+-- NOTE on query shape — Redshift restriction: a correlated subquery cannot
+-- appear inside an OR predicate ("This type of correlated subquery pattern is
+-- not supported due to internal error", error 500310). This template used to
+-- express every lab/condition check as EXISTS(...)/NOT EXISTS(...), several of
+-- them OR-combined (e.g. Cr OR CrCl; the TBil/AST/ALT/coag alternatives) —
+-- Redshift rejects that shape outright. Instead we join the base cohort to
+-- @lab_cohort_table ONCE (keyed on subject only), collapse each test_id into a
+-- 0/1 flag per subject via conditional aggregation (no correlation), and then
+-- apply the eligibility logic as plain boolean algebra over those flags. Same
+-- semantics as the EXISTS version (a flag is 1 iff a qualifying record exists
+-- for that subject in the relevant window), same eligibility_2b/2c/2d pattern.
 -- =============================================================================
 
 DELETE FROM @target_database_schema.@target_cohort_table
@@ -37,259 +49,96 @@ DELETE FROM @target_database_schema.@target_cohort_table
 
 INSERT INTO @target_database_schema.@target_cohort_table
   (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
-SELECT @target_cohort_id AS cohort_definition_id,
-       tc.subject_id,
-       tc.cohort_start_date,
-       tc.cohort_end_date
-  FROM @target_database_schema.@target_cohort_table tc
- WHERE tc.cohort_definition_id = @cohort1_id
+WITH base AS (
+  SELECT tc.subject_id, tc.cohort_start_date, tc.cohort_end_date,
+         DATEADD(day, -@lab_window_before_days, tc.cohort_start_date) AS win_lo,
+         DATEADD(day,  @lab_window_after_days,  tc.cohort_start_date) AS win_hi
+    FROM @target_database_schema.@target_cohort_table tc
+   WHERE tc.cohort_definition_id = @cohort1_id
 
-   /* ----- Washout: no systemic regimen in [index - 365, index - 30) ----- */
-   AND NOT EXISTS (
-         SELECT 1
-           FROM @target_database_schema.@regimen_episode_table re
-          WHERE CAST(re.person_id AS BIGINT) = tc.subject_id
-            AND re.episode_start_date <  DATEADD(day, -30, tc.cohort_start_date)
-            AND re.episode_end_date   >= DATEADD(day, -365, tc.cohort_start_date)
-       )
+     /* ----- Washout: no systemic regimen in [index - 365, index - 30) ----- */
+     AND NOT EXISTS (
+           SELECT 1
+             FROM @target_database_schema.@regimen_episode_table re
+            WHERE CAST(re.person_id AS BIGINT) = tc.subject_id
+              AND re.episode_start_date <  DATEADD(day, -30, tc.cohort_start_date)
+              AND re.episode_end_date   >= DATEADD(day, -365, tc.cohort_start_date)
+         )
+),
+labs AS (
+  SELECT b.subject_id, b.cohort_start_date, b.cohort_end_date, b.win_lo, b.win_hi,
+         lab.cohort_definition_id AS test_id, lab.cohort_start_date AS lab_date
+    FROM base b
+    LEFT JOIN @target_database_schema.@lab_cohort_table lab
+      ON lab.subject_id = b.subject_id
+     AND lab.cohort_start_date <= b.win_hi   -- every criterion below needs at most this upper bound
+),
+flags AS (
+  SELECT subject_id, cohort_start_date, cohort_end_date,
+    MAX(CASE WHEN test_id IN (24, 25, 26)           AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_ecog_0_2,
+    MAX(CASE WHEN test_id = 14                      AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_gfr30,
+    MAX(CASE WHEN test_id = 4                       AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_anc,
+    MAX(CASE WHEN test_id = 19                      AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_plt,
+    MAX(CASE WHEN test_id = 15                      AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_hb,
+    MAX(CASE WHEN test_id = 8                       AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_cr,
+    MAX(CASE WHEN test_id = 7                       AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_crcl,
+    MAX(CASE WHEN test_id = 22                      AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_tbil_le15,
+    MAX(CASE WHEN test_id = 23                      AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_tbil_gt15,
+    MAX(CASE WHEN test_id = 9                       AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_dbil,
+    MAX(CASE WHEN test_id = 21                      AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_tbil_le3,
+    MAX(CASE WHEN test_id = 29                      AND lab_date <= win_hi                 THEN 1 ELSE 0 END) AS f_gilbert,
+    MAX(CASE WHEN test_id = 5                       AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_ast_le25,
+    MAX(CASE WHEN test_id = 6                       AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_ast_le5,
+    MAX(CASE WHEN test_id = 28                      AND lab_date <= win_hi                 THEN 1 ELSE 0 END) AS f_livermet,
+    MAX(CASE WHEN test_id = 2                       AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_alt_le25,
+    MAX(CASE WHEN test_id = 3                       AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_alt_le5,
+    MAX(CASE WHEN test_id = 18                      AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_inr,
+    MAX(CASE WHEN test_id = 31                      AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_anticoag,
+    MAX(CASE WHEN test_id = 20                      AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_pt,
+    MAX(CASE WHEN test_id = 1                       AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_aptt,
+    MAX(CASE WHEN test_id = 17                      AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_hba1c_lt6,
+    MAX(CASE WHEN test_id = 16                      AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_hba1c_7_8,
+    MAX(CASE WHEN test_id = 35                      AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_polyuria,
+    MAX(CASE WHEN test_id = 36                      AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_polydipsia,
+    MAX(CASE WHEN test_id = 33                      AND lab_date <= win_hi                 THEN 1 ELSE 0 END) AS f_neuropathy,
+    MAX(CASE WHEN test_id = 34                      AND lab_date <= win_hi                 THEN 1 ELSE 0 END) AS f_skin
+  FROM labs
+  GROUP BY subject_id, cohort_start_date, cohort_end_date
+)
+SELECT @target_cohort_id AS cohort_definition_id,
+       subject_id, cohort_start_date, cohort_end_date
+  FROM flags
+ WHERE
 
    /* ----- Combination-therapy eligible ----- */
-
-   -- [24-26] ECOG 0-2 at index
-   AND EXISTS (
-         SELECT 1
-           FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id IN (24, 25, 26)
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
-
-   -- [14] GFR >= 30 mL/min
-   AND EXISTS (
-         SELECT 1
-           FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 14
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
-
-   -- [4] ANC >= 1500/uL
-   AND EXISTS (
-         SELECT 1
-           FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 4
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
-
-   -- [19] Platelets >= 100,000/uL
-   AND EXISTS (
-         SELECT 1
-           FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 19
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
-
-   -- [15] Hb >= 9.0 g/dL  (mmol/L folds in via unit normalisation)
-   AND EXISTS (
-         SELECT 1
-           FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 15
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
+       f_ecog_0_2 = 1        -- [24-26] ECOG 0-2 at index
+   AND f_gfr30    = 1        -- [14] GFR >= 30 mL/min
+   AND f_anc      = 1        -- [4]  ANC >= 1500/uL
+   AND f_plt      = 1        -- [19] Platelets >= 100,000/uL
+   AND f_hb       = 1        -- [15] Hb >= 9.0 g/dL
 
    -- Creatinine: [8] Cr <= 1.5 ULN  OR  [7] CrCl >= 30
-   AND (
-         EXISTS (
-               SELECT 1
-                 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 8
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-         OR EXISTS (
-               SELECT 1
-                 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 7
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-       )
+   AND (f_cr = 1 OR f_crcl = 1)
 
    -- Bilirubin: [22] TBil <= 1.5 ULN
    --         OR ([23] TBil > 1.5 ULN AND [9] DBil <= ULN)
    --         OR ([21] TBil <= 3 ULN AND Gilbert's syndrome [29])
    AND (
-         EXISTS (
-               SELECT 1
-                 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 22
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-         OR (
-               EXISTS (
-                     SELECT 1
-                       FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 23
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                    AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-               AND EXISTS (
-                     SELECT 1
-                       FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 9
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                    AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-             )
-         OR ( EXISTS (
-               SELECT 1
-                 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 21
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-               AND EXISTS (   -- [29] Gilbert's syndrome gates the TBil <= 3x ULN branch
-                     SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 29
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date <= DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-             )
+         f_tbil_le15 = 1
+         OR (f_tbil_gt15 = 1 AND f_dbil    = 1)
+         OR (f_tbil_le3  = 1 AND f_gilbert = 1)
        )
 
    -- AST: [5] <= 2.5 ULN  OR  ([6] <= 5 ULN AND [28] liver metastasis)
-   AND (
-         EXISTS (
-               SELECT 1
-                 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 5
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-         OR (
-               EXISTS (
-                     SELECT 1
-                       FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 6
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                    AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-               AND EXISTS (
-                     SELECT 1
-                       FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 28
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date <= DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-             )
-       )
+   AND (f_ast_le25 = 1 OR (f_ast_le5 = 1 AND f_livermet = 1))
 
    -- ALT: [2] <= 2.5 ULN  OR  ([3] <= 5 ULN AND [28] liver metastasis)
-   AND (
-         EXISTS (
-               SELECT 1
-                 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 2
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-         OR (
-               EXISTS (
-                     SELECT 1
-                       FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 3
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                    AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-               AND EXISTS (
-                     SELECT 1
-                       FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 28
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date <= DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-             )
-       )
+   AND (f_alt_le25 = 1 OR (f_alt_le5 = 1 AND f_livermet = 1))
 
-   -- Coag extrinsic limb — protocol: (INR <= 1.5 ULN OR PT <= 1.5 ULN).
-   -- INR is the normalised form of PT (same coagulation pathway), so either one
-   -- present-and-passing satisfies this limb; anticoagulant therapy (test 31)
-   -- waives it. aPTT is a separate AND (below).
-   AND (
-       ( -- [18] INR <= 1.5 ULN
-         EXISTS (
-         SELECT 1
-           FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 18
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
-      OR EXISTS (   -- [31] on anticoagulant therapy waives this coag criterion
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 31
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-       )
-      OR
-       ( -- [20] PT <= 1.5 ULN
-         EXISTS (
-         SELECT 1
-           FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 20
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
-      OR EXISTS (   -- [31] on anticoagulant therapy waives this coag criterion
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 31
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-       )
-   )
-
-   -- [1] aPTT <= 1.5 ULN  (anticoagulant exception wired via test 31, below)
-   AND (
-         EXISTS (
-         SELECT 1
-           FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 1
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
-      OR EXISTS (   -- [31] on anticoagulant therapy waives this coag criterion
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 31
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-   )
+   -- Coag: protocol (INR <= 1.5 ULN OR PT <= 1.5 ULN), aPTT <= 1.5 ULN
+   -- separately; anticoagulant therapy (test 31) waives either limb.
+   AND (f_inr = 1 OR f_pt = 1 OR f_anticoag = 1)
+   AND (f_aptt = 1 OR f_anticoag = 1)
 
    /* ----- Enfortumab-eligible ----- */
 
@@ -307,45 +156,14 @@ SELECT @target_cohort_id AS cohort_definition_id,
    -- below to AND on clinical grounds alone: it encodes a stated requirement and
    -- may only change via a requirements/protocol update. See COHORT_AUDIT.md F4.
    AND (
-         EXISTS (
-               SELECT 1
-                 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 17
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-         OR (
-               EXISTS (
-                     SELECT 1
-                       FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 16
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                    AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-               -- (NO polyuria [35] OR NO polydipsia [36]) — literal PDF; see NOTE above
-               AND (
-                  NOT EXISTS (SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 35 AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                    AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date))
-                  OR NOT EXISTS (SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 36 AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                    AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date))
-               )
-             )
+         f_hba1c_lt6 = 1
+         OR (f_hba1c_7_8 = 1 AND (f_polyuria = 0 OR f_polydipsia = 0))
        )
 
    -- Enfortumab: no significant peripheral neuropathy (test 33); pre-existing
    -- = any record on/before index+14d.
-   AND NOT EXISTS (SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 33 AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date <= DATEADD(day, @lab_window_after_days, tc.cohort_start_date))
+   AND f_neuropathy = 0
 
    -- Enfortumab: no pre-existing significant skin disorders (test 34).
-   AND NOT EXISTS (SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 34 AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date <= DATEADD(day, @lab_window_after_days, tc.cohort_start_date))
+   AND f_skin = 0
 ;

--- a/sql/eligibility_2b.sql
+++ b/sql/eligibility_2b.sql
@@ -4,19 +4,22 @@
 -- Protocol: Cohort 1 + washout + combination-therapy eligible + NOT enfortumab-
 -- eligible + cisplatin-eligible. Index/end dates inherited from Cohort 1.
 --
--- See eligibility_2a.sql for full test_id reference (lab_cohorts.sql ids 1-23)
--- and for why this template is written as flag columns rather than nested
--- EXISTS/OR: Redshift rejects correlated subqueries combined with OR (error
--- 500310), and several of these criteria are OR alternatives (Cr/CrCl, TBil,
--- AST, ALT, coag). Planned ids: 24-26 ECOG; 28 liver mets; 32 neuropathy;
+-- See eligibility_2a.sql for full test_id reference (lab_cohorts.sql ids 1-23),
+-- for why this template is written as flag columns rather than nested
+-- EXISTS/OR (Redshift rejects correlated subqueries combined with OR — error
+-- 500310, and several of these criteria are OR alternatives: Cr/CrCl, TBil,
+-- AST, ALT, coag), and for why the flags are materialised into a #temp table
+-- via SELECT...INTO rather than combined directly with INSERT (WITH+INSERT
+-- clause ordering is not portable across dialects).
+-- Planned ids: 24-26 ECOG; 28 liver mets; 32 neuropathy;
 -- 37 NYHA < III; 39 hearing loss grade < 2.
 -- =============================================================================
 
 DELETE FROM @target_database_schema.@target_cohort_table
  WHERE cohort_definition_id = @target_cohort_id;
 
-INSERT INTO @target_database_schema.@target_cohort_table
-  (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
+DROP TABLE IF EXISTS #elig2b_tmp;
+
 WITH base AS (
   SELECT tc.subject_id, tc.cohort_start_date, tc.cohort_end_date,
          DATEADD(day, -@lab_window_before_days, tc.cohort_start_date) AS win_lo,
@@ -80,8 +83,8 @@ flags AS (
   FROM labs
   GROUP BY subject_id, cohort_start_date, cohort_end_date
 )
-SELECT @target_cohort_id AS cohort_definition_id,
-       subject_id, cohort_start_date, cohort_end_date
+SELECT subject_id, cohort_start_date, cohort_end_date
+  INTO #elig2b_tmp
   FROM flags
  WHERE
 
@@ -111,3 +114,12 @@ SELECT @target_cohort_id AS cohort_definition_id,
    AND f_hearing    = 0   -- Cisplatin: no significant audiometric hearing loss (test 40).
    AND f_neuropathy = 0   -- Cisplatin: no significant peripheral neuropathy (test 33).
 ;
+
+INSERT INTO @target_database_schema.@target_cohort_table
+  (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
+SELECT @target_cohort_id AS cohort_definition_id,
+       subject_id, cohort_start_date, cohort_end_date
+  FROM #elig2b_tmp
+;
+
+DROP TABLE IF EXISTS #elig2b_tmp;

--- a/sql/eligibility_2b.sql
+++ b/sql/eligibility_2b.sql
@@ -4,9 +4,12 @@
 -- Protocol: Cohort 1 + washout + combination-therapy eligible + NOT enfortumab-
 -- eligible + cisplatin-eligible. Index/end dates inherited from Cohort 1.
 --
--- See eligibility_2a.sql for full test_id reference (lab_cohorts.sql ids 1-23).
--- Planned ids: 24-26 ECOG; 28 liver mets; 32 neuropathy; 37 NYHA < III;
---              39 hearing loss grade < 2.
+-- See eligibility_2a.sql for full test_id reference (lab_cohorts.sql ids 1-23)
+-- and for why this template is written as flag columns rather than nested
+-- EXISTS/OR: Redshift rejects correlated subqueries combined with OR (error
+-- 500310), and several of these criteria are OR alternatives (Cr/CrCl, TBil,
+-- AST, ALT, coag). Planned ids: 24-26 ECOG; 28 liver mets; 32 neuropathy;
+-- 37 NYHA < III; 39 hearing loss grade < 2.
 -- =============================================================================
 
 DELETE FROM @target_database_schema.@target_cohort_table
@@ -14,257 +17,97 @@ DELETE FROM @target_database_schema.@target_cohort_table
 
 INSERT INTO @target_database_schema.@target_cohort_table
   (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
-SELECT @target_cohort_id AS cohort_definition_id,
-       tc.subject_id,
-       tc.cohort_start_date,
-       tc.cohort_end_date
-  FROM @target_database_schema.@target_cohort_table tc
- WHERE tc.cohort_definition_id = @cohort1_id
+WITH base AS (
+  SELECT tc.subject_id, tc.cohort_start_date, tc.cohort_end_date,
+         DATEADD(day, -@lab_window_before_days, tc.cohort_start_date) AS win_lo,
+         DATEADD(day,  @lab_window_after_days,  tc.cohort_start_date) AS win_hi
+    FROM @target_database_schema.@target_cohort_table tc
 
-   /* ----- Washout ----- */
-   AND NOT EXISTS (
-         SELECT 1
-           FROM @target_database_schema.@regimen_episode_table re
-          WHERE CAST(re.person_id AS BIGINT) = tc.subject_id
-            AND re.episode_start_date <  DATEADD(day, -30, tc.cohort_start_date)
-            AND re.episode_end_date   >= DATEADD(day, -365, tc.cohort_start_date)
-       )
+    /* ----- NOT enfortumab-eligible: exact anti-join on cohort 2a ----- */
+    -- 2a is generated before this cohort, so we exclude anyone already claimed
+    -- by the EV arm (captures the full EV definition: HbA1c AND neuropathy AND
+    -- skin). Plain anti-join, no correlated subquery.
+    LEFT JOIN @target_database_schema.@target_cohort_table ev
+      ON ev.subject_id = tc.subject_id
+     AND ev.cohort_definition_id = @cohort2a_id
+   WHERE tc.cohort_definition_id = @cohort1_id
+     AND ev.subject_id IS NULL
+
+     /* ----- Washout ----- */
+     AND NOT EXISTS (
+           SELECT 1
+             FROM @target_database_schema.@regimen_episode_table re
+            WHERE CAST(re.person_id AS BIGINT) = tc.subject_id
+              AND re.episode_start_date <  DATEADD(day, -30, tc.cohort_start_date)
+              AND re.episode_end_date   >= DATEADD(day, -365, tc.cohort_start_date)
+         )
+),
+labs AS (
+  SELECT b.subject_id, b.cohort_start_date, b.cohort_end_date, b.win_lo, b.win_hi,
+         lab.cohort_definition_id AS test_id, lab.cohort_start_date AS lab_date
+    FROM base b
+    LEFT JOIN @target_database_schema.@lab_cohort_table lab
+      ON lab.subject_id = b.subject_id
+     AND lab.cohort_start_date <= b.win_hi
+),
+flags AS (
+  SELECT subject_id, cohort_start_date, cohort_end_date,
+    MAX(CASE WHEN test_id IN (24, 25, 26) AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_ecog_0_2,
+    MAX(CASE WHEN test_id IN (24, 25)     AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_ecog_0_1,
+    MAX(CASE WHEN test_id = 14            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_gfr30,
+    MAX(CASE WHEN test_id = 13            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_gfr60,
+    MAX(CASE WHEN test_id = 4             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_anc,
+    MAX(CASE WHEN test_id = 19            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_plt,
+    MAX(CASE WHEN test_id = 15            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_hb,
+    MAX(CASE WHEN test_id = 8             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_cr,
+    MAX(CASE WHEN test_id = 7             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_crcl,
+    MAX(CASE WHEN test_id = 22            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_tbil_le15,
+    MAX(CASE WHEN test_id = 23            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_tbil_gt15,
+    MAX(CASE WHEN test_id = 9             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_dbil,
+    MAX(CASE WHEN test_id = 21            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_tbil_le3,
+    MAX(CASE WHEN test_id = 29            AND lab_date <= win_hi                 THEN 1 ELSE 0 END) AS f_gilbert,
+    MAX(CASE WHEN test_id = 5             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_ast_le25,
+    MAX(CASE WHEN test_id = 6             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_ast_le5,
+    MAX(CASE WHEN test_id = 28            AND lab_date <= win_hi                 THEN 1 ELSE 0 END) AS f_livermet,
+    MAX(CASE WHEN test_id = 2             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_alt_le25,
+    MAX(CASE WHEN test_id = 3             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_alt_le5,
+    MAX(CASE WHEN test_id = 18            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_inr,
+    MAX(CASE WHEN test_id = 31            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_anticoag,
+    MAX(CASE WHEN test_id = 20            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_pt,
+    MAX(CASE WHEN test_id = 1             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_aptt,
+    MAX(CASE WHEN test_id = 40            AND lab_date <= win_hi                 THEN 1 ELSE 0 END) AS f_hearing,
+    MAX(CASE WHEN test_id = 33            AND lab_date <= win_hi                 THEN 1 ELSE 0 END) AS f_neuropathy
+  FROM labs
+  GROUP BY subject_id, cohort_start_date, cohort_end_date
+)
+SELECT @target_cohort_id AS cohort_definition_id,
+       subject_id, cohort_start_date, cohort_end_date
+  FROM flags
+ WHERE
 
    /* ----- Combination-therapy eligible (same criteria as 2a) ----- */
+       f_ecog_0_2 = 1
+   AND f_gfr30    = 1
+   AND f_anc      = 1
+   AND f_plt      = 1
+   AND f_hb       = 1
+   AND (f_cr = 1 OR f_crcl = 1)
+   AND (
+         f_tbil_le15 = 1
+         OR (f_tbil_gt15 = 1 AND f_dbil    = 1)
+         OR (f_tbil_le3  = 1 AND f_gilbert = 1)
+       )
+   AND (f_ast_le25 = 1 OR (f_ast_le5 = 1 AND f_livermet = 1))
+   AND (f_alt_le25 = 1 OR (f_alt_le5 = 1 AND f_livermet = 1))
+   AND (f_inr = 1 OR f_pt = 1 OR f_anticoag = 1)
+   AND (f_aptt = 1 OR f_anticoag = 1)
 
-   AND EXISTS (
-         SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id IN (24, 25, 26)
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
-   AND EXISTS (
-         SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 14
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
-   AND EXISTS (
-         SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 4
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
-   AND EXISTS (
-         SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 19
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
-   AND EXISTS (
-         SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 15
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
-   AND (
-         EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 8
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-         OR EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 7
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-       )
-   AND (
-         EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 22
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-         OR (
-               EXISTS (
-                     SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 23
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                    AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-               AND EXISTS (
-                     SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 9
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                    AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-             )
-         OR ( EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 21
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-               AND EXISTS (   -- [29] Gilbert's syndrome gates the TBil <= 3x ULN branch
-                     SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 29
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date <= DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-             )
-       )
-   AND (
-         EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 5
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-         OR (
-               EXISTS (
-                     SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 6
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                    AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-               AND EXISTS (
-                     SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 28
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date <= DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-             )
-       )
-   AND (
-         EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 2
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-         OR (
-               EXISTS (
-                     SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 3
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                    AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-               AND EXISTS (
-                     SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 28
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date <= DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-             )
-       )
-   -- Coag extrinsic limb — protocol: (INR <= 1.5 ULN OR PT <= 1.5 ULN).
-   -- INR is the normalised form of PT (same pathway); either satisfies. aPTT
-   -- is a separate AND (below). Anticoagulant therapy (test 31) waives it.
-   AND (
-       ( -- [18] INR <= 1.5 ULN
-         EXISTS (
-         SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 18
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
-      OR EXISTS (   -- [31] on anticoagulant therapy waives this coag criterion
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 31
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-       )
-      OR
-       ( -- [20] PT <= 1.5 ULN
-         EXISTS (
-         SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 20
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
-      OR EXISTS (   -- [31] on anticoagulant therapy waives this coag criterion
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 31
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-       )
-   )
-   AND (
-         EXISTS (
-         SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 1
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
-      OR EXISTS (   -- [31] on anticoagulant therapy waives this coag criterion
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 31
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-   )
-
-   /* ----- NOT enfortumab-eligible: exact anti-join on cohort 2a ----- */
-   -- 2a is generated before this cohort, so we exclude anyone already claimed by
-   -- the EV arm (captures the full EV definition: HbA1c AND neuropathy AND skin).
-
-   AND NOT EXISTS (
-         SELECT 1 FROM @target_database_schema.@target_cohort_table ev
-          WHERE ev.subject_id = tc.subject_id
-            AND ev.cohort_definition_id = @cohort2a_id
-       )
+   -- NOT enfortumab-eligible handled by the ev anti-join in `base` above.
 
    /* ----- Cisplatin-eligible ----- */
-
-   -- [24-25] ECOG 0-1
-   AND EXISTS (
-         SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id IN (24, 25)
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
-
-   -- [13] GFR > 60 mL/min
-   AND EXISTS (
-         SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 13
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
-
-   -- NYHA class < III: IGNORED for now (assume-pass) — no NYHA concept set yet.
-   AND 1 = 1
-
-   -- Cisplatin: no significant audiometric hearing loss (test 40).
-   AND NOT EXISTS (SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 40 AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date <= DATEADD(day, @lab_window_after_days, tc.cohort_start_date))
-
-   -- Cisplatin: no significant peripheral neuropathy (test 33).
-   AND NOT EXISTS (SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 33 AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date <= DATEADD(day, @lab_window_after_days, tc.cohort_start_date))
+   AND f_ecog_0_1 = 1     -- [24-25] ECOG 0-1
+   AND f_gfr60    = 1     -- [13] GFR > 60 mL/min
+   AND 1 = 1              -- NYHA class < III: IGNORED for now (assume-pass) — no NYHA concept set yet.
+   AND f_hearing    = 0   -- Cisplatin: no significant audiometric hearing loss (test 40).
+   AND f_neuropathy = 0   -- Cisplatin: no significant peripheral neuropathy (test 33).
 ;

--- a/sql/eligibility_2c.sql
+++ b/sql/eligibility_2c.sql
@@ -4,9 +4,12 @@
 -- Protocol: Cohort 1 + washout + combination-therapy eligible + NOT enfortumab-
 -- eligible + NOT cisplatin-eligible + carboplatin-eligible.
 --
--- See eligibility_2a.sql for full test_id reference and for why this template
+-- See eligibility_2a.sql for full test_id reference, for why this template
 -- uses flag columns rather than nested EXISTS/OR (Redshift rejects correlated
--- subqueries combined with OR — error 500310).
+-- subqueries combined with OR — error 500310), and for why the flags are
+-- materialised into a #temp table via SELECT...INTO rather than combined
+-- directly with INSERT (WITH+INSERT clause ordering is not portable across
+-- dialects).
 -- Planned ids: 24-26 ECOG; 28 liver mets; 33 neuropathy >= 2; 38 NYHA >= III;
 --              40 hearing loss grade >= 2.
 -- =============================================================================
@@ -14,8 +17,8 @@
 DELETE FROM @target_database_schema.@target_cohort_table
  WHERE cohort_definition_id = @target_cohort_id;
 
-INSERT INTO @target_database_schema.@target_cohort_table
-  (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
+DROP TABLE IF EXISTS #elig2c_tmp;
+
 WITH base AS (
   SELECT tc.subject_id, tc.cohort_start_date, tc.cohort_end_date,
          DATEADD(day, -@lab_window_before_days, tc.cohort_start_date) AS win_lo,
@@ -85,8 +88,8 @@ flags AS (
   FROM labs
   GROUP BY subject_id, cohort_start_date, cohort_end_date
 )
-SELECT @target_cohort_id AS cohort_definition_id,
-       subject_id, cohort_start_date, cohort_end_date
+SELECT subject_id, cohort_start_date, cohort_end_date
+  INTO #elig2c_tmp
   FROM flags
  WHERE
 
@@ -119,3 +122,12 @@ SELECT @target_cohort_id AS cohort_definition_id,
          OR f_neuropathy = 1 -- [33] peripheral neuropathy present (grade >= 2 proxy)
        )
 ;
+
+INSERT INTO @target_database_schema.@target_cohort_table
+  (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
+SELECT @target_cohort_id AS cohort_definition_id,
+       subject_id, cohort_start_date, cohort_end_date
+  FROM #elig2c_tmp
+;
+
+DROP TABLE IF EXISTS #elig2c_tmp;

--- a/sql/eligibility_2c.sql
+++ b/sql/eligibility_2c.sql
@@ -4,7 +4,9 @@
 -- Protocol: Cohort 1 + washout + combination-therapy eligible + NOT enfortumab-
 -- eligible + NOT cisplatin-eligible + carboplatin-eligible.
 --
--- See eligibility_2a.sql for full test_id reference.
+-- See eligibility_2a.sql for full test_id reference and for why this template
+-- uses flag columns rather than nested EXISTS/OR (Redshift rejects correlated
+-- subqueries combined with OR — error 500310).
 -- Planned ids: 24-26 ECOG; 28 liver mets; 33 neuropathy >= 2; 38 NYHA >= III;
 --              40 hearing loss grade >= 2.
 -- =============================================================================
@@ -14,270 +16,106 @@ DELETE FROM @target_database_schema.@target_cohort_table
 
 INSERT INTO @target_database_schema.@target_cohort_table
   (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
-SELECT @target_cohort_id AS cohort_definition_id,
-       tc.subject_id,
-       tc.cohort_start_date,
-       tc.cohort_end_date
-  FROM @target_database_schema.@target_cohort_table tc
- WHERE tc.cohort_definition_id = @cohort1_id
+WITH base AS (
+  SELECT tc.subject_id, tc.cohort_start_date, tc.cohort_end_date,
+         DATEADD(day, -@lab_window_before_days, tc.cohort_start_date) AS win_lo,
+         DATEADD(day,  @lab_window_after_days,  tc.cohort_start_date) AS win_hi
+    FROM @target_database_schema.@target_cohort_table tc
 
-   /* ----- Washout ----- */
-   AND NOT EXISTS (
-         SELECT 1
-           FROM @target_database_schema.@regimen_episode_table re
-          WHERE CAST(re.person_id AS BIGINT) = tc.subject_id
-            AND re.episode_start_date <  DATEADD(day, -30, tc.cohort_start_date)
-            AND re.episode_end_date   >= DATEADD(day, -365, tc.cohort_start_date)
-       )
+    /* ----- NOT enfortumab-eligible: exact anti-join on cohort 2a ----- */
+    LEFT JOIN @target_database_schema.@target_cohort_table ev
+      ON ev.subject_id = tc.subject_id
+     AND ev.cohort_definition_id = @cohort2a_id
+
+    /* ----- NOT cisplatin-eligible: exact anti-join on cohort 2b ----- */
+    -- 2a/2b are generated before this cohort; each anti-join excludes anyone
+    -- already claimed by that arm's full definition (not just its distinguishing
+    -- criteria). Plain anti-joins, no correlated subqueries.
+    LEFT JOIN @target_database_schema.@target_cohort_table cis
+      ON cis.subject_id = tc.subject_id
+     AND cis.cohort_definition_id = @cohort2b_id
+   WHERE tc.cohort_definition_id = @cohort1_id
+     AND ev.subject_id  IS NULL
+     AND cis.subject_id IS NULL
+
+     /* ----- Washout ----- */
+     AND NOT EXISTS (
+           SELECT 1
+             FROM @target_database_schema.@regimen_episode_table re
+            WHERE CAST(re.person_id AS BIGINT) = tc.subject_id
+              AND re.episode_start_date <  DATEADD(day, -30, tc.cohort_start_date)
+              AND re.episode_end_date   >= DATEADD(day, -365, tc.cohort_start_date)
+         )
+),
+labs AS (
+  SELECT b.subject_id, b.cohort_start_date, b.cohort_end_date, b.win_lo, b.win_hi,
+         lab.cohort_definition_id AS test_id, lab.cohort_start_date AS lab_date
+    FROM base b
+    LEFT JOIN @target_database_schema.@lab_cohort_table lab
+      ON lab.subject_id = b.subject_id
+     AND lab.cohort_start_date <= b.win_hi
+),
+flags AS (
+  SELECT subject_id, cohort_start_date, cohort_end_date,
+    MAX(CASE WHEN test_id IN (24, 25, 26) AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_ecog_0_2,
+    MAX(CASE WHEN test_id = 26            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_ecog2,
+    MAX(CASE WHEN test_id = 14            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_gfr30,
+    MAX(CASE WHEN test_id = 11            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_gfr_30_60,
+    MAX(CASE WHEN test_id = 4             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_anc,
+    MAX(CASE WHEN test_id = 19            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_plt,
+    MAX(CASE WHEN test_id = 15            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_hb,
+    MAX(CASE WHEN test_id = 8             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_cr,
+    MAX(CASE WHEN test_id = 7             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_crcl,
+    MAX(CASE WHEN test_id = 22            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_tbil_le15,
+    MAX(CASE WHEN test_id = 23            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_tbil_gt15,
+    MAX(CASE WHEN test_id = 9             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_dbil,
+    MAX(CASE WHEN test_id = 21            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_tbil_le3,
+    MAX(CASE WHEN test_id = 29            AND lab_date <= win_hi                 THEN 1 ELSE 0 END) AS f_gilbert,
+    MAX(CASE WHEN test_id = 5             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_ast_le25,
+    MAX(CASE WHEN test_id = 6             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_ast_le5,
+    MAX(CASE WHEN test_id = 28            AND lab_date <= win_hi                 THEN 1 ELSE 0 END) AS f_livermet,
+    MAX(CASE WHEN test_id = 2             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_alt_le25,
+    MAX(CASE WHEN test_id = 3             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_alt_le5,
+    MAX(CASE WHEN test_id = 18            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_inr,
+    MAX(CASE WHEN test_id = 31            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_anticoag,
+    MAX(CASE WHEN test_id = 20            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_pt,
+    MAX(CASE WHEN test_id = 1             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_aptt,
+    MAX(CASE WHEN test_id = 40            AND lab_date <= win_hi                 THEN 1 ELSE 0 END) AS f_hearing,
+    MAX(CASE WHEN test_id = 33            AND lab_date <= win_hi                 THEN 1 ELSE 0 END) AS f_neuropathy
+  FROM labs
+  GROUP BY subject_id, cohort_start_date, cohort_end_date
+)
+SELECT @target_cohort_id AS cohort_definition_id,
+       subject_id, cohort_start_date, cohort_end_date
+  FROM flags
+ WHERE
 
    /* ----- Combination-therapy eligible (same criteria as 2a) ----- */
+       f_ecog_0_2 = 1
+   AND f_gfr30    = 1
+   AND f_anc      = 1
+   AND f_plt      = 1
+   AND f_hb       = 1
+   AND (f_cr = 1 OR f_crcl = 1)
+   AND (
+         f_tbil_le15 = 1
+         OR (f_tbil_gt15 = 1 AND f_dbil    = 1)
+         OR (f_tbil_le3  = 1 AND f_gilbert = 1)
+       )
+   AND (f_ast_le25 = 1 OR (f_ast_le5 = 1 AND f_livermet = 1))
+   AND (f_alt_le25 = 1 OR (f_alt_le5 = 1 AND f_livermet = 1))
+   AND (f_inr = 1 OR f_pt = 1 OR f_anticoag = 1)
+   AND (f_aptt = 1 OR f_anticoag = 1)
 
-   AND EXISTS (
-         SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id IN (24, 25, 26)
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
-   AND EXISTS (
-         SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 14
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
-   AND EXISTS (
-         SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 4
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
-   AND EXISTS (
-         SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 19
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
-   AND EXISTS (
-         SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 15
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
-   AND (
-         EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 8
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-         OR EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 7
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-       )
-   AND (
-         EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 22
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-         OR (
-               EXISTS (
-                     SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 23
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                    AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-               AND EXISTS (
-                     SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 9
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                    AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-             )
-         OR ( EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 21
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-               AND EXISTS (   -- [29] Gilbert's syndrome gates the TBil <= 3x ULN branch
-                     SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 29
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date <= DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-             )
-       )
-   AND (
-         EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 5
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-         OR (
-               EXISTS (
-                     SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 6
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                    AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-               AND EXISTS (
-                     SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 28
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date <= DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-             )
-       )
-   AND (
-         EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 2
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-         OR (
-               EXISTS (
-                     SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 3
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                    AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-               AND EXISTS (
-                     SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 28
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date <= DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-             )
-       )
-   -- Coag extrinsic limb — protocol: (INR <= 1.5 ULN OR PT <= 1.5 ULN).
-   -- INR is the normalised form of PT (same pathway); either satisfies. aPTT
-   -- is a separate AND (below). Anticoagulant therapy (test 31) waives it.
-   AND (
-       ( -- [18] INR <= 1.5 ULN
-         EXISTS (
-         SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 18
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
-      OR EXISTS (   -- [31] on anticoagulant therapy waives this coag criterion
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 31
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-       )
-      OR
-       ( -- [20] PT <= 1.5 ULN
-         EXISTS (
-         SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 20
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
-      OR EXISTS (   -- [31] on anticoagulant therapy waives this coag criterion
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 31
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-       )
-   )
-   AND (
-         EXISTS (
-         SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-          WHERE lab.cohort_definition_id = 1
-            AND lab.subject_id = tc.subject_id
-            AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                        AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-       )
-      OR EXISTS (   -- [31] on anticoagulant therapy waives this coag criterion
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 31
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-   )
-
-   /* ----- NOT enfortumab-eligible: exact anti-join on cohort 2a ----- */
-   -- 2a is generated before this cohort, so we exclude anyone already claimed by
-   -- the EV arm (captures the full EV definition: HbA1c AND neuropathy AND skin).
-
-   AND NOT EXISTS (
-         SELECT 1 FROM @target_database_schema.@target_cohort_table ev
-          WHERE ev.subject_id = tc.subject_id
-            AND ev.cohort_definition_id = @cohort2a_id
-       )
-
-   /* ----- NOT cisplatin-eligible: exact anti-join on cohort 2b ----- */
-   -- 2b is generated before this cohort; excludes anyone already on the cisplatin
-   -- arm (captures the full cisplatin definition, not just ECOG/GFR).
-
-   AND NOT EXISTS (
-         SELECT 1 FROM @target_database_schema.@target_cohort_table cis
-          WHERE cis.subject_id = tc.subject_id
-            AND cis.cohort_definition_id = @cohort2b_id
-       )
+   -- NOT enfortumab-eligible / NOT cisplatin-eligible handled by the ev/cis
+   -- anti-joins in `base` above.
 
    /* ----- Carboplatin-eligible (any one) ----- */
-
    AND (
-         -- [26] ECOG 2
-         EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 26
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-         -- [11] GFR 30-60 mL/min
-         OR EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 11
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
+         f_ecog2      = 1   -- [26] ECOG 2
+         OR f_gfr_30_60 = 1 -- [11] GFR 30-60 mL/min
          -- NYHA class >= III: IGNORED for now (no NYHA concept set).
-         -- [40] audiometric hearing loss present (grade >= 2 proxy)
-         OR EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 40
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date <= DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-         -- [33] peripheral neuropathy present (grade >= 2 proxy)
-         OR EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 33
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date <= DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
+         OR f_hearing   = 1 -- [40] audiometric hearing loss present (grade >= 2 proxy)
+         OR f_neuropathy = 1 -- [33] peripheral neuropathy present (grade >= 2 proxy)
        )
 ;

--- a/sql/eligibility_2d.sql
+++ b/sql/eligibility_2d.sql
@@ -4,8 +4,11 @@
 -- Protocol: Cohort 1 + washout + NOT combination-therapy eligible + pembro/atezo
 -- renal/PS/comorbidity criteria + PD-L1 biomarker.
 --
--- NOT combo eligible is expressed as failing at least one combination criterion
--- (De Morgan: NOT (A AND B AND ...) = (NOT A) OR (NOT B) OR ...).
+-- See eligibility_2a.sql for full test_id reference and for why this template
+-- uses flag columns rather than nested EXISTS/OR (Redshift rejects correlated
+-- subqueries combined with OR — error 500310). With combo-eligibility reduced
+-- to boolean flag columns, "NOT combination-therapy eligible" is just
+-- NOT (combo_eligible_expression) — no manual De Morgan expansion needed.
 --
 -- Planned ids: 24-27 ECOG; 28 liver mets; 41 comorbidities grade > 2;
 --              42 PD-L1 CPS >= 10; 43 PD-L1 TIC >= 5%.
@@ -16,251 +19,93 @@ DELETE FROM @target_database_schema.@target_cohort_table
 
 INSERT INTO @target_database_schema.@target_cohort_table
   (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
-SELECT @target_cohort_id AS cohort_definition_id,
-       tc.subject_id,
-       tc.cohort_start_date,
-       tc.cohort_end_date
-  FROM @target_database_schema.@target_cohort_table tc
- WHERE tc.cohort_definition_id = @cohort1_id
+WITH base AS (
+  SELECT tc.subject_id, tc.cohort_start_date, tc.cohort_end_date,
+         DATEADD(day, -@lab_window_before_days, tc.cohort_start_date) AS win_lo,
+         DATEADD(day,  @lab_window_after_days,  tc.cohort_start_date) AS win_hi
+    FROM @target_database_schema.@target_cohort_table tc
+   WHERE tc.cohort_definition_id = @cohort1_id
 
-   /* ----- Washout ----- */
-   AND NOT EXISTS (
-         SELECT 1
-           FROM @target_database_schema.@regimen_episode_table re
-          WHERE CAST(re.person_id AS BIGINT) = tc.subject_id
-            AND re.episode_start_date <  DATEADD(day, -30, tc.cohort_start_date)
-            AND re.episode_end_date   >= DATEADD(day, -365, tc.cohort_start_date)
-       )
+     /* ----- Washout ----- */
+     AND NOT EXISTS (
+           SELECT 1
+             FROM @target_database_schema.@regimen_episode_table re
+            WHERE CAST(re.person_id AS BIGINT) = tc.subject_id
+              AND re.episode_start_date <  DATEADD(day, -30, tc.cohort_start_date)
+              AND re.episode_end_date   >= DATEADD(day, -365, tc.cohort_start_date)
+         )
+),
+labs AS (
+  SELECT b.subject_id, b.cohort_start_date, b.cohort_end_date, b.win_lo, b.win_hi,
+         lab.cohort_definition_id AS test_id, lab.cohort_start_date AS lab_date
+    FROM base b
+    LEFT JOIN @target_database_schema.@lab_cohort_table lab
+      ON lab.subject_id = b.subject_id
+     AND lab.cohort_start_date <= b.win_hi
+),
+flags AS (
+  SELECT subject_id, cohort_start_date, cohort_end_date,
+    MAX(CASE WHEN test_id IN (24, 25, 26) AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_ecog_0_2,
+    MAX(CASE WHEN test_id = 26            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_ecog2,
+    MAX(CASE WHEN test_id = 27            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_ecog_ge3,
+    MAX(CASE WHEN test_id = 14            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_gfr30,
+    MAX(CASE WHEN test_id = 10            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_gfr_lt30,
+    MAX(CASE WHEN test_id = 12            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_gfr_lt60,
+    MAX(CASE WHEN test_id = 4             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_anc,
+    MAX(CASE WHEN test_id = 19            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_plt,
+    MAX(CASE WHEN test_id = 15            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_hb,
+    MAX(CASE WHEN test_id = 8             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_cr,
+    MAX(CASE WHEN test_id = 7             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_crcl,
+    MAX(CASE WHEN test_id = 22            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_tbil_le15,
+    MAX(CASE WHEN test_id = 23            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_tbil_gt15,
+    MAX(CASE WHEN test_id = 9             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_dbil,
+    MAX(CASE WHEN test_id = 21            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_tbil_le3,
+    MAX(CASE WHEN test_id = 29            AND lab_date <= win_hi                 THEN 1 ELSE 0 END) AS f_gilbert,
+    MAX(CASE WHEN test_id = 5             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_ast_le25,
+    MAX(CASE WHEN test_id = 6             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_ast_le5,
+    MAX(CASE WHEN test_id = 28            AND lab_date <= win_hi                 THEN 1 ELSE 0 END) AS f_livermet,
+    MAX(CASE WHEN test_id = 2             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_alt_le25,
+    MAX(CASE WHEN test_id = 3             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_alt_le5,
+    MAX(CASE WHEN test_id = 18            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_inr,
+    MAX(CASE WHEN test_id = 31            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_anticoag,
+    MAX(CASE WHEN test_id = 20            AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_pt,
+    MAX(CASE WHEN test_id = 1             AND lab_date BETWEEN win_lo AND win_hi THEN 1 ELSE 0 END) AS f_aptt
+  FROM labs
+  GROUP BY subject_id, cohort_start_date, cohort_end_date
+)
+SELECT @target_cohort_id AS cohort_definition_id,
+       subject_id, cohort_start_date, cohort_end_date
+  FROM flags
+ WHERE
 
    /* ----- NOT combination-therapy eligible ----- */
-
-   AND (
-         -- Fail ECOG 0-2
-         NOT EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id IN (24, 25, 26)
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-         -- Fail GFR >= 30
-         OR NOT EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 14
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-         OR NOT EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 4
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-         OR NOT EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 19
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-         OR NOT EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 15
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-         OR NOT (
-               EXISTS (
-                     SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 8
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                    AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-               OR EXISTS (
-                     SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 7
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                    AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-             )
-         OR NOT (
-               EXISTS (
-                     SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 22
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                    AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-               OR (
-                     EXISTS (
-                           SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                            WHERE lab.cohort_definition_id = 23
-                              AND lab.subject_id = tc.subject_id
-                              AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                          AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                         )
-                     AND EXISTS (
-                           SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                            WHERE lab.cohort_definition_id = 9
-                              AND lab.subject_id = tc.subject_id
-                              AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                          AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                         )
-                   )
-               OR ( EXISTS (
-                     SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 21
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                    AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-               AND EXISTS (   -- [29] Gilbert's syndrome gates the TBil <= 3x ULN branch
-                     SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 29
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date <= DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-             )
-             )
-         OR NOT (
-               EXISTS (
-                     SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 5
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                    AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-               OR (
-                     EXISTS (
-                           SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                            WHERE lab.cohort_definition_id = 6
-                              AND lab.subject_id = tc.subject_id
-                              AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                          AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                         )
-                     AND EXISTS (
-                           SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                            WHERE lab.cohort_definition_id = 28
-                              AND lab.subject_id = tc.subject_id
-                              AND lab.cohort_start_date <= DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                         )
-                   )
-             )
-         OR NOT (
-               EXISTS (
-                     SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 2
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                    AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-               OR (
-                     EXISTS (
-                           SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                            WHERE lab.cohort_definition_id = 3
-                              AND lab.subject_id = tc.subject_id
-                              AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                          AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                         )
-                     AND EXISTS (
-                           SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                            WHERE lab.cohort_definition_id = 28
-                              AND lab.subject_id = tc.subject_id
-                              AND lab.cohort_start_date <= DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                         )
-                   )
-             )
-         -- Fail the (INR OR PT) extrinsic limb of combo eligibility: NEITHER INR
-         -- nor PT passes, AND the patient is not anticoagulated. This is the
-         -- De Morgan negation of the corrected combo clause (INR OR PT) AND aPTT
-         -- — the INR and PT failures are one conjoined term, not two OR terms.
-         OR (
-            NOT EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 18
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-            AND NOT EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 20
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-            AND NOT EXISTS (   -- [31] and NOT on anticoagulant therapy
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 31
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
+   NOT (
+         f_ecog_0_2 = 1
+     AND f_gfr30    = 1
+     AND f_anc      = 1
+     AND f_plt      = 1
+     AND f_hb       = 1
+     AND (f_cr = 1 OR f_crcl = 1)
+     AND (
+           f_tbil_le15 = 1
+           OR (f_tbil_gt15 = 1 AND f_dbil    = 1)
+           OR (f_tbil_le3  = 1 AND f_gilbert = 1)
          )
-         OR (
-            NOT EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 1
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-            AND NOT EXISTS (   -- [31] and NOT on anticoagulant therapy
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 31
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-         )
+     AND (f_ast_le25 = 1 OR (f_ast_le5 = 1 AND f_livermet = 1))
+     AND (f_alt_le25 = 1 OR (f_alt_le5 = 1 AND f_livermet = 1))
+     AND (f_inr = 1 OR f_pt = 1 OR f_anticoag = 1)
+     AND (f_aptt = 1 OR f_anticoag = 1)
        )
 
    /* ----- Pembro/atezo renal / performance / comorbidity path ----- */
-
    AND (
-         -- [10] GFR < 30 mL/min
-         EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 10
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-         -- [27] ECOG >= 3
-         OR EXISTS (
-               SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                WHERE lab.cohort_definition_id = 27
-                  AND lab.subject_id = tc.subject_id
-                  AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                              AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-             )
-         -- [26] ECOG 2 AND [12] GFR < 60
-         OR (
-               EXISTS (
-                     SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 26
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                    AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-               AND EXISTS (
-                     SELECT 1 FROM @target_database_schema.@lab_cohort_table lab
-                      WHERE lab.cohort_definition_id = 12
-                        AND lab.subject_id = tc.subject_id
-                        AND lab.cohort_start_date BETWEEN DATEADD(day, -@lab_window_before_days, tc.cohort_start_date)
-                                                    AND DATEADD(day, @lab_window_after_days, tc.cohort_start_date)
-                   )
-             )
+         f_gfr_lt30 = 1                       -- [10] GFR < 30 mL/min
+         OR f_ecog_ge3 = 1                    -- [27] ECOG >= 3
+         OR (f_ecog2 = 1 AND f_gfr_lt60 = 1)  -- [26] ECOG 2 AND [12] GFR < 60
          -- TODO second pass: [41] comorbidities grade > 2
        )
 
    /* ----- PD-L1 biomarker (required; not yet encoded) ----- */
-
    -- PD-L1 (tests 42/43) IGNORED for now; template kept, set always-true
    -- (was 1 = 0) so 2d is not forced empty. Restore when PD-L1 is encoded.
    AND 1 = 1

--- a/sql/eligibility_2d.sql
+++ b/sql/eligibility_2d.sql
@@ -4,11 +4,14 @@
 -- Protocol: Cohort 1 + washout + NOT combination-therapy eligible + pembro/atezo
 -- renal/PS/comorbidity criteria + PD-L1 biomarker.
 --
--- See eligibility_2a.sql for full test_id reference and for why this template
+-- See eligibility_2a.sql for full test_id reference, for why this template
 -- uses flag columns rather than nested EXISTS/OR (Redshift rejects correlated
--- subqueries combined with OR — error 500310). With combo-eligibility reduced
--- to boolean flag columns, "NOT combination-therapy eligible" is just
--- NOT (combo_eligible_expression) — no manual De Morgan expansion needed.
+-- subqueries combined with OR — error 500310), and for why the flags are
+-- materialised into a #temp table via SELECT...INTO rather than combined
+-- directly with INSERT (WITH+INSERT clause ordering is not portable across
+-- dialects). With combo-eligibility reduced to boolean flag columns,
+-- "NOT combination-therapy eligible" is just NOT (combo_eligible_expression)
+-- — no manual De Morgan expansion needed.
 --
 -- Planned ids: 24-27 ECOG; 28 liver mets; 41 comorbidities grade > 2;
 --              42 PD-L1 CPS >= 10; 43 PD-L1 TIC >= 5%.
@@ -17,8 +20,8 @@
 DELETE FROM @target_database_schema.@target_cohort_table
  WHERE cohort_definition_id = @target_cohort_id;
 
-INSERT INTO @target_database_schema.@target_cohort_table
-  (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
+DROP TABLE IF EXISTS #elig2d_tmp;
+
 WITH base AS (
   SELECT tc.subject_id, tc.cohort_start_date, tc.cohort_end_date,
          DATEADD(day, -@lab_window_before_days, tc.cohort_start_date) AS win_lo,
@@ -73,8 +76,8 @@ flags AS (
   FROM labs
   GROUP BY subject_id, cohort_start_date, cohort_end_date
 )
-SELECT @target_cohort_id AS cohort_definition_id,
-       subject_id, cohort_start_date, cohort_end_date
+SELECT subject_id, cohort_start_date, cohort_end_date
+  INTO #elig2d_tmp
   FROM flags
  WHERE
 
@@ -110,3 +113,12 @@ SELECT @target_cohort_id AS cohort_definition_id,
    -- (was 1 = 0) so 2d is not forced empty. Restore when PD-L1 is encoded.
    AND 1 = 1
 ;
+
+INSERT INTO @target_database_schema.@target_cohort_table
+  (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
+SELECT @target_cohort_id AS cohort_definition_id,
+       subject_id, cohort_start_date, cohort_end_date
+  FROM #elig2d_tmp
+;
+
+DROP TABLE IF EXISTS #elig2d_tmp;

--- a/sql/eligibility_input_coverage.sql
+++ b/sql/eligibility_input_coverage.sql
@@ -23,14 +23,15 @@ passed AS (
    GROUP BY lab.cohort_definition_id
 ),
 tested AS (
-  SELECT raw.test_id AS test_id,
+  -- alias "rlr" (not "raw"): RAW is a reserved word in Redshift and breaks as a bare alias
+  SELECT rlr.test_id AS test_id,
          COUNT(DISTINCT t1a.subject_id) AS n_tested
     FROM t1a
-    JOIN @work_database_schema.@raw_lab_results_table raw
-      ON raw.person_id = t1a.subject_id
-     AND raw.measurement_date BETWEEN DATEADD(day, -@lab_window_before_days, t1a.cohort_start_date)
+    JOIN @work_database_schema.@raw_lab_results_table rlr
+      ON rlr.person_id = t1a.subject_id
+     AND rlr.measurement_date BETWEEN DATEADD(day, -@lab_window_before_days, t1a.cohort_start_date)
                                   AND DATEADD(day,  @lab_window_after_days, t1a.cohort_start_date)
-   GROUP BY raw.test_id
+   GROUP BY rlr.test_id
 )
 SELECT COALESCE(p.test_id, t.test_id) AS test_id,
        t.n_tested,


### PR DESCRIPTION
## Summary

- Redshift rejects correlated subqueries combined with `OR` (`This type of correlated subquery pattern is not supported due to internal error`, 500310). `eligibility_2a/2b/2c/2d.sql` built most of their lab/condition checks as `EXISTS(...)/NOT EXISTS(...)` blocks, several `OR`-combined (Cr/CrCl, TBil/AST/ALT alternatives, INR/PT/aPTT coag alternatives, HbA1c branch) — this is what broke cohort generation for T2a EV eligible mBC (id 22) in `03_main_cohorts.R`.
- Rewrote all four templates to join the base cohort to `@lab_cohort_table` once (non-correlated), collapse each `test_id` into a 0/1 flag column via conditional aggregation, and express the eligibility logic as plain boolean algebra over those flags instead of nested `EXISTS`/`OR`.
- Converted the 2a/2b anti-joins (NOT enfortumab-eligible / NOT cisplatin-eligible) from correlated `NOT EXISTS` to `LEFT JOIN ... IS NULL` anti-joins for the same reason. Left the single `AND`-only washout `NOT EXISTS` as-is since Redshift's restriction is specific to `OR`.
- No changes to `R/03_main_cohorts.R` — same `@`-parameters as before.

## Dialect portability

Combining the flags CTE directly with the final `INSERT` isn't portable: Snowflake requires `WITH` nested *after* the `INSERT`'s column list, while T-SQL (SQL Server) requires `WITH` to *precede* `INSERT` entirely — mutually exclusive placements, and SqlRender does not reorder clauses between dialects. Fixed by materialising the flags CTE into a `#temp` table via `SELECT ... INTO #temp FROM ...` (the SqlRender-portable idiom already used elsewhere in OHDSI SQL — translates to native `SELECT INTO` on SQL Server, `CREATE TEMP TABLE AS` on Postgres/Redshift/Snowflake), then a plain CTE-free `INSERT INTO ... SELECT FROM #temp`.

## Reserved-word fix (eligibility_input_coverage.sql)

Separately, `eligibility_input_coverage.sql` (called from `R/05_eligibility_coverage.R`, downstream of `03_main_cohorts.R`) used `raw` as a bare table alias for `@raw_lab_results_table`. `RAW` is a reserved keyword in Redshift, and fails as a bare identifier — same class of bug as the earlier `offset` -> `val_offset` fix in `lab_cohorts.sql`. Renamed the alias to `rlr`. Searched the rest of `sql/*.sql` for the same alias.column pattern against Redshift's full reserved-word list; no other instances found.